### PR TITLE
Show Exceptions in Package Contents Table, Update txtmark Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,17 @@ Then you can use TeXDoclet as an alternate doclet in the `pom.xml` file of any p
 					<sourcepath>src/main/java:src/test/java</sourcepath>
 					<useStandardDocletOptions>false</useStandardDocletOptions><!-- important ! -->
 					<destDir>apidocs_tex</destDir>
-					<additionalparam>
-						-tree
-						-hyperref
-						-output TeXDoclet.tex
-						-createpdf
-						-title "TeXDoclet Java Documentation"
-						-subtitle "Created with Javadoc TeXDoclet Doclet"
-						-author "Greg Wonderly \and S{\"o}ren Caspersen \and Stefan Marx"
-						-subpackages org
-						-shortinherited
-					</additionalparam>
+					<additionalOptions>
+						<additionalOption>-tree<additionalOption>
+						<additionalOption>-hyperref<additionalOption>
+						<additionalOption>-output TeXDoclet.tex<additionalOption>
+						<additionalOption>-createpdf<additionalOption>
+						<additionalOption>-title "TeXDoclet Java Documentation"<additionalOption>
+						<additionalOption>-subtitle "Created with Javadoc TeXDoclet Doclet"<additionalOption>
+						<additionalOption>-author "Greg Wonderly \and S{\"o}ren Caspersen \and Stefan Marx"<additionalOption>
+						<additionalOption>-subpackages org<additionalOption>
+						<additionalOption>-shortinherited<additionalOption>
+					</additionalOptions>
 				</configuration>
 			</plugin>
 			...

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,12 @@
 			<id>scala-tools</id>
 			<url>http://scala-tools.org/repo-releases</url>
 		</repository>
+    <!-- not available - pull from central repo instead
 		<repository>
 			<id>renejeschke-releases</id>
 			<url>http://maven.renejeschke.de</url>
 		</repository>
+    -->
 	</repositories>
 
 	<dependencies>
@@ -76,7 +78,7 @@
             <version>1.6.0</version>
             <scope>system</scope>
             <systemPath>${toolsjar}</systemPath>
-        </dependency>	
+        </dependency>
 		<dependency>
 			<groupId>com.keypoint</groupId>
 			<artifactId>png-encoder</artifactId>
@@ -103,7 +105,7 @@
 		<dependency>
 		    <groupId>com.github.rjeschke</groupId>
 		    <artifactId>txtmark</artifactId>
-		    <version>0.7</version>
+		    <version>0.8</version><!-- version 0.7 not available anymore -->
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,6 @@
 			<id>scala-tools</id>
 			<url>http://scala-tools.org/repo-releases</url>
 		</repository>
-    <!-- not available - pull from central repo instead
-		<repository>
-			<id>renejeschke-releases</id>
-			<url>http://maven.renejeschke.de</url>
-		</repository>
-    -->
 	</repositories>
 
 	<dependencies>
@@ -105,7 +99,7 @@
 		<dependency>
 		    <groupId>com.github.rjeschke</groupId>
 		    <artifactId>txtmark</artifactId>
-		    <version>0.8</version><!-- version 0.7 not available anymore -->
+		    <version>0.8</version>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/org/stfm/texdoclet/TeXDoclet.java
+++ b/src/main/java/org/stfm/texdoclet/TeXDoclet.java
@@ -707,6 +707,7 @@ public class TeXDoclet extends Doclet {
 				}
 				tocForClasses("Interfaces", pkg.interfaces);
 				tocForClasses("Classes", pkg.classes);
+				tocForClasses("Exceptions", pkg.exceptions);
 				os.println("\\vskip .1in");
 				if (useHr) {
 					os.println("\\rule{\\hsize}{.7mm}");


### PR DESCRIPTION
When recently playing around with TeXDoclet, I noticed that exceptions are not shown in the package contents table of the containing package. So I added them.

It seems like the dependency txtmark v0.7 that is used by TeXDoclet is not available from the repository defined in the pom anymore (in fact, the repository itself is unavailable). It seems like the creator of txtmark [migrated the deployment to Maven Central](https://mvnrepository.com/artifact/com.github.rjeschke/txtmark), where txtmark v0.8 is available. This is why I updated the dependency to use version 0.8.

When using TeXDoclet with Maven I had a hard time passing options to the doclet via the pom.xml. I found out that the `<additionalparam>` option of the maven-javadoc-plugin that is used in the README has been replaced by `<additionalOptions>` (See https://issues.apache.org/jira/browse/MJAVADOC-475). I updated the README to use this new option. The old one doesn't work anymore.