### PR TITLE
Use raggedright for exception tree too

### DIFF
--- a/src/main/java/org/stfm/texdoclet/TeXDoclet.java
+++ b/src/main/java/org/stfm/texdoclet/TeXDoclet.java
@@ -1091,7 +1091,9 @@ public class TeXDoclet extends Doclet {
 		}
 		if (exceptionHierachy.root.size() != 0) {
 			os.println("\\" + sectionLevels[1] + "*{Exceptions}");
+			os.println("{\\raggedright");
 			exceptionHierachy.printTree(root, overviewindent);
+			os.println("}");
 		}
 
 		// Errors


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/40410676/84332075-9e71f780-ab94-11ea-925d-a52bf5631d54.png)

After:
![image](https://user-images.githubusercontent.com/40410676/84332027-87cba080-ab94-11ea-9678-2814d104bb0c.png)
